### PR TITLE
Fix markdown syntax for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ SWTableViewCell
 
 An easy-to-use UITableViewCell subclass that implements a swipeable content view which exposes utility buttons (similar to iOS 7 Mail Application)
 
-##Usage
+## Usage
 In your Podfile:
 <pre>pod 'SWTableViewCell', '~> 0.3.7'</pre>
 
 Or just clone this repo and manually add source to project
 
-##Functionality
-###Right Utility Buttons
+## Functionality
+### Right Utility Buttons
 Utility buttons that become visible on the right side of the Table View Cell when the user swipes left. This behavior is similar to that seen in the iOS apps Mail and Reminders.
 
 <p align="center"><img src="http://i.imgur.com/gDZFRpr.gif"/></p>
 
-###Left Utility Buttons
+### Left Utility Buttons
 Utility buttons that become visible on the left side of the Table View Cell when the user swipes right. 
 
 <p align="center"><img src="http://i.imgur.com/qt6aISz.gif"/></p>
 
-###Features
+### Features
 * Dynamic utility button scalling. As you add more buttons to a cell, the other buttons on that side get smaller to make room
 * Smart selection: The cell will pick up touch events and either scroll the cell back to center or fire the delegate method `- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath` 
 <p align="center"><img src="http://i.imgur.com/TYGx9h8.gif"/></p>
@@ -33,9 +33,9 @@ So the cell will not be considered selected when the user touches the cell while
 * Create utilty buttons with either a title or an icon along with a RGB color
 * Tested on iOS 6.1 and above, including iOS 7
 
-##Usage
+## Usage
 
-###Standard Table View Cells
+### Standard Table View Cells
 
 In your `tableView:cellForRowAtIndexPath:` method you set up the SWTableView cell and add an arbitrary amount of utility buttons to it using the included `NSMutableArray+SWUtilityButtons` category.
 
@@ -93,7 +93,7 @@ In your `tableView:cellForRowAtIndexPath:` method you set up the SWTableView cel
 }
 ```
 
-###Custom Table View Cells
+### Custom Table View Cells
 
 Thanks to [Matt Bowman](https://github.com/MattCBowman) you can now create custom table view cells using Interface Builder that have the capabilities of an SWTableViewCell
 
@@ -157,7 +157,7 @@ Then, in the `tableView:cellForRowAtIndexPath:` method of your `UITableViewDataS
 }
 ```
 
-###Delegate
+### Delegate
 
 The delegate `SWTableViewCellDelegate` is used by the developer to find out which button was pressed. There are five methods:
 
@@ -180,7 +180,7 @@ The delegate `SWTableViewCellDelegate` is used by the developer to find out whic
 
 The index signifies which utility button the user pressed, for each side the button indices are ordered from right to left 0...n
 
-####Example
+#### Example
 
 ```objc
 #pragma mark - SWTableViewDelegate
@@ -226,17 +226,17 @@ The index signifies which utility button the user pressed, for each side the but
 
 (This is all code from the included example project)
 
-###Gotchas
+### Gotchas
 
 #### Seperator Insets
 * If you have left utility button on iOS 7, I recommend changing your Table View's seperatorInset so the seperator stretches the length of the screen
 <pre> tableView.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0); </pre>
 
 
-##Contributing
+## Contributing
 Use [Github issues](https://github.com/cewendel/SWTableViewCell/issues) to track bugs and feature requests.
 
-##Contact
+## Contact
 
 Chris Wendel
 
@@ -245,8 +245,3 @@ Chris Wendel
 ## Licence
 
 MIT 
-
-
-
-
-


### PR DESCRIPTION
Markdown headers require a space between the #s and the text
Remove excess whitespace at end of file